### PR TITLE
Make nodealarmproxy require-able

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
 	"email" : "m@mattmartz.com",
 	"version" : "0.6.2",
 	"description" : "Use this to communcate to an envisalink 3 module for home alarm monitoring.",
-	"repository" : { 
+	"repository" : {
 		"type" : "git",
 		"url" : "https://github.com/oehokie/NodeAlarmProxy"
-	}
+	},
+	"main": "nodealarmproxy"
 }


### PR DESCRIPTION
package.json needs a "main" property for node require() to work properly.  I needed to add this to get nodealarmproxy to work in my current project, figured I'd push it back!
