### PR TITLE
Checksum is case sensitive and should be in upper case

### DIFF
--- a/nodealarmproxy.js
+++ b/nodealarmproxy.js
@@ -221,7 +221,7 @@ function sendcommand(addressee,command) {
 	for (var i = 0; i<command.length; i++) {
 		checksum += command.charCodeAt(i);
 	}
-	checksum = checksum.toString(16).slice(-2);
+	checksum = checksum.toString(16).slice(-2).toUpperCase();
 	addressee.write(command+checksum+'\r\n');
 }
 


### PR DESCRIPTION
I ran into this issue myself recently and noticed others having the same problem: https://github.com/dustindclark/homebridge-envisalink/issues/3
