### PR TITLE
add support for callback in manualCommand

### DIFF
--- a/envisalink.js
+++ b/envisalink.js
@@ -176,7 +176,7 @@ exports.tpicommands = {
     'bytes':3,
     'post':'Acknowledged',
     'send':'',
-    'action':''
+    'action':'command-completed'
   },
   '501' : {
     'name':'Command Error',
@@ -184,7 +184,7 @@ exports.tpicommands = {
     'bytes':0,
     'post':'',
     'send':'',
-    'action':''
+    'action': 'command-error'
   },
   '502' : {
     'name':'System Error',
@@ -192,7 +192,7 @@ exports.tpicommands = {
     'bytes':3,
     'post':'has been detected.',
     'send':'',
-    'action':''
+    'action':'command-error'
   },
   '505' : {
     'name':'Login Interaction',


### PR DESCRIPTION
I was writing a function to enable/disable the alarm and
when I called manualCommand it complained about 'callback'
not being defined.

This PR resolves that problem and adds the code required so that
you can provide a callback that gets invoked when a response
to the command is received.  If there was an error, the error
will be passed as the first parameter to the callback.